### PR TITLE
feat: add markdown field to FullPost from gateway response

### DIFF
--- a/src/domain/post.ts
+++ b/src/domain/post.ts
@@ -76,6 +76,7 @@ export class FullPost implements Post {
   public readonly truncatedBody: string
   public readonly publishedAt: Date
   public readonly htmlBody: string
+  public readonly markdown: string
   public readonly slug: string
   public readonly createdAt: Date
   public readonly reactions?: Record<string, number>
@@ -96,6 +97,7 @@ export class FullPost implements Post {
     this.publishedAt = new Date(rawData.published_at)
     this.url = rawData.url
     this.htmlBody = rawData.html_body || ''
+    this.markdown = rawData.markdown || ''
     this.slug = rawData.slug
     this.createdAt = new Date(rawData.published_at)
     this.reactions = rawData.reactions ?? undefined

--- a/src/internal/types/gateway.ts
+++ b/src/internal/types/gateway.ts
@@ -85,6 +85,7 @@ export const GatewayFullPostC = t.intersection([
   t.partial({
     subtitle: t.union([t.string, t.null]),
     html_body: t.union([t.string, t.null]),
+    markdown: t.union([t.string, t.null]),
     truncated_body: t.union([t.string, t.null]),
     reactions: t.union([t.record(t.string, t.number), t.null]),
     restacks: t.union([t.number, t.null]),

--- a/tests/unit/fixtures/gateway-data.ts
+++ b/tests/unit/fixtures/gateway-data.ts
@@ -36,6 +36,7 @@ export const makeGatewayFullPost = (id: number, title: string) => ({
   url: `https://example.com/post-${id}`,
   published_at: '2023-01-01T00:00:00Z',
   html_body: '<p>Full HTML content with <strong>formatting</strong></p>',
+  markdown: '# Test\n\nFull markdown content with **formatting**',
   truncated_body: 'Truncated content',
   reactions: { '❤️': 5 },
   restacks: 2,

--- a/tests/unit/posts.test.ts
+++ b/tests/unit/posts.test.ts
@@ -137,10 +137,11 @@ describe('FullPost Entity', () => {
   })
 
   describe('properties', () => {
-    it('should expose id, title, htmlBody, subtitle, and publishedAt', () => {
+    it('should expose id, title, htmlBody, markdown, subtitle, and publishedAt', () => {
       expect(fullPost.id).toBe(789)
       expect(fullPost.title).toBe('Full Test Post')
       expect(fullPost.htmlBody).toBe('<p>Full HTML content with <strong>formatting</strong></p>')
+      expect(fullPost.markdown).toBe('# Test\n\nFull markdown content with **formatting**')
       expect(fullPost.subtitle).toBe('Test subtitle')
       expect(fullPost.publishedAt).toBeInstanceOf(Date)
     })


### PR DESCRIPTION
The Substack gateway GET /v1/posts/{post_id} endpoint now returns a
markdown property. Expose it in GatewayFullPostC codec and FullPost
domain model alongside the existing htmlBody field.

https://claude.ai/code/session_01NpoUfFj4pwDhDY3LuYgEM8